### PR TITLE
Would you be interested in using something like clap clap to simplify CLI and add features?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ doc  = false
 
 [dependencies]
 lzf = "*"
-getopts = "*"
+clap = "*"
 rustc-serialize = "*"
 regex = "*"
 byteorder = "*"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@ extern crate rustc_serialize as serialize;
 extern crate regex;
 extern crate byteorder;
 
+#[macro_use]
+extern crate clap;
+
 use std::io::Read;
 
 #[doc(hidden)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,13 +14,15 @@ pub type RdbResult<T> = Result<T, RdbError>;
 
 pub type RdbOk = RdbResult<()>;
 
-#[derive(Debug,PartialEq)]
-pub enum Type {
-    String,
-    List,
-    Set,
-    SortedSet,
-    Hash
+arg_enum!{
+    #[derive(Debug,PartialEq)]
+    pub enum Type {
+        String,
+        List,
+        Set,
+        SortedSet,
+        Hash
+    }
 }
 
 impl Type {


### PR DESCRIPTION
@badboy  If you're interested, this PR simplifies `src/main.rs` by a few dozen LOC while simultaneously adding some additional features to the CLI. If not, no hard feelings, just thought I'd ask since working through projects like this help me keep pushing `clap` forward and making it better :)

The main additional features you get "for free" are
- Suggestions on Error
- Context-Aware Usage Strings
- Other small niceties

`clap` also supports tons of additional features that you may be able to take advantage of in the future as well. This PR literally just translates the `getopts` functionality, along with all the other things you get by default.
## Suggestions

For example, when spelling mistakes are made. Trying `--fomat plain` (note the missing `r` in `format`) outputs

```
$ rdb mydump.rdb --fomat plain
error: The argument '--fomat' isn't valid
    Did you mean --format ?

USAGE:
    rdb <dump_file> --format <format>

For more information try --help
```
## Context-Aware Usage Strings

Say a user has a myriad of options, but still makes a typo or mistake. The usage string takes all the options they were attempting to use, and inserts them. Example (note the missing value for `--keys`:

```
$ rdb mydump -d 23 -t plain --keys
error: The argument '--keys <keys>' requires a value but none was supplied

USAGE:
    rdb <dump_file> --keys <keys> --type <type>... --databases <dbs>...

For more information try --help
```
## Other Niceties

This is things like the version auto-incremented with your `Cargo.toml` version, colored output (can be turned off if you don't like it), etc.
