### PR TITLE
Add speedy hex-keys output option

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -6,7 +6,6 @@ pub trait Filter {
     fn matches_db(&self, _db: u32) -> bool { true }
     fn matches_type(&self, _enc_type: u8) -> bool { true }
     fn matches_key(&self, _key: &[u8]) -> bool { true }
-
 }
 
 pub struct Simple {

--- a/src/formatter/hexkeys.rs
+++ b/src/formatter/hexkeys.rs
@@ -1,0 +1,29 @@
+#![allow(unused_must_use)]
+
+use formatter::Formatter;
+use std::io;
+use std::io::Write;
+use super::write_str;
+use serialize::hex::{ToHex};
+
+pub struct HexKeys {
+    out: Box<Write+'static>,
+}
+
+impl HexKeys {
+    pub fn new() -> HexKeys {
+        let out = Box::new(io::stdout());
+        HexKeys {
+            out: out,
+        }
+    }
+}
+
+impl Formatter for HexKeys {
+    fn should_read_objects(&mut self) -> bool { false }
+
+    fn matched_key(&mut self, key: &[u8]) {
+        self.out.write_all(key.to_hex().as_bytes());
+        write_str(&mut self.out, "\n");
+    }
+}

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -3,11 +3,13 @@ use std::io::Write;
 pub use self::nil::Nil;
 pub use self::plain::Plain;
 pub use self::json::JSON;
+pub use self::hexkeys::HexKeys;
 pub use self::protocol::Protocol;
 
 use super::types::EncodingType;
 
 pub mod nil;
+pub mod hexkeys;
 pub mod plain;
 pub mod json;
 pub mod protocol;
@@ -23,11 +25,15 @@ pub trait Formatter {
     fn end_rdb(&mut self) {}
     fn checksum(&mut self, checksum: &[u8]) {}
 
+    fn should_read_objects(&mut self) -> bool { true }
+
     fn start_database(&mut self, db_index: u32) {}
     fn end_database(&mut self, db_index: u32) {}
 
     fn resizedb(&mut self, db_size: u32, expires_size: u32) {}
     fn aux_field(&mut self, key: &[u8], value: &[u8]) {}
+
+    fn matched_key(&mut self, _key: &[u8]) {}
 
     fn set(&mut self, key: &[u8], value: &[u8], expiry: Option<u64>) {}
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ pub fn main() {
     let program = args.next().unwrap();
     let mut opts = Options::new();
 
-    opts.optopt("f", "format", "Format to output. Valid: json, plain, nil, protocol", "FORMAT");
+    opts.optopt("f", "format", "Format to output. Valid: json, hex-keys, plain, nil, protocol", "FORMAT");
     opts.optopt("k", "keys", "Keys to show. Can be a regular expression", "KEYS");
     opts.optmulti("d", "databases", "Database to show. Can be specified multiple times", "DB");
     opts.optmulti("t", "type", "Type to show. Can be specified multiple times", "TYPE");
@@ -89,6 +89,9 @@ pub fn main() {
         match &f[..] {
             "json" => {
                 res = rdb::parse(reader, rdb::formatter::JSON::new(), filter);
+            },
+            "hex-keys" => {
+                res = rdb::parse(reader, rdb::formatter::HexKeys::new(), filter);
             },
             "plain" => {
                 res = rdb::parse(reader, rdb::formatter::Plain::new(), filter);


### PR DESCRIPTION
Consider this a request for comment, as I'm *very* new to rust and needed to get this working for a personal use case. There isn't an open source product that can easily/neatly extract binary keys out of a redis database, so whipped up this.

In any case there is a bug in your `skip` method that sometimes does not read the correct number of bytes even if they are available.